### PR TITLE
Sync hotreload cog from SeaCogs

### DIFF
--- a/hotreload/data/meta.json
+++ b/hotreload/data/meta.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://c.csw.im/cswimr/tidegear/raw/branch/main/schema/meta/meta.json",
-  "version": "1.5.18",
+  "version": "1.5.19",
   "authors": [
     {
       "name": "cswimr",

--- a/hotreload/info.json
+++ b/hotreload/info.json
@@ -17,7 +17,7 @@
     0
   ],
   "requirements": [
-    "red-tidegear>=1.23.1",
+    "red-tidegear>=1.23.4",
     "watchdog~=6.0"
   ],
   "tags": [

--- a/hotreload/info.json
+++ b/hotreload/info.json
@@ -17,7 +17,7 @@
     0
   ],
   "requirements": [
-    "red-tidegear>=1.23.4",
+    "red-tidegear>=1.23.8",
     "watchdog~=6.0"
   ],
   "tags": [


### PR DESCRIPTION
This PR syncs the latest changes from the `hotreload` cog in the `SeaCogs` repository. Repository URL: https://c.csw.im/cswimr/SeaCogs